### PR TITLE
Use feed's title if item does not have one

### DIFF
--- a/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
+++ b/src/github.com/matrix-org/go-neb/services/rssbot/rssbot.go
@@ -349,6 +349,11 @@ func (s *Service) sendToRooms(cli *gomatrix.Client, feedURL string, feed *gofeed
 }
 
 func itemToHTML(feed *gofeed.Feed, item gofeed.Item) gomatrix.HTMLMessage {
+	// If an item does not have a title, try using the feed's title instead
+	if item.Title == "" {
+		item.Title = feed.Title
+	}
+	
 	return &gomatrix.HTMLMessage{
 		Body: fmt.Sprintf("%s: %s (%s)",
 			html.EscapeString(feed.Title), html.EscapeString(item.Title), html.EscapeString(item.Link)),


### PR DESCRIPTION
This prevents a link from not being shown if an item's title could not be extracted.

Workaround(?) fix for #284.